### PR TITLE
Prevent calling `crawl()` after calling custom callback method

### DIFF
--- a/pholcidae.py
+++ b/pholcidae.py
@@ -238,7 +238,7 @@ class Pholcidae:
             callback = self._settings.callbacks[url_pattern]
             if callback:
                 getattr(self, callback)(data)
-                pass
+                return
         self.crawl(data)
 
     ########################## CRAWLING METHODS ################################


### PR DESCRIPTION
From 0029558, `crawl()` method is invoked after provided custom callback method is called.
If this is an intended change, please forgive me and close the issue.
