### PR TITLE
launch spider in new thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# Created by .gitignore support plugin (hsz.mobi)
+
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template 
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+__author__ = 'd01'
+from pholcidae import Pholcidae

--- a/test.py
+++ b/test.py
@@ -1,7 +1,7 @@
 from pholcidae import Pholcidae
 
-class MyTestSpider(Pholcidae):
 
+class MyTestSpider(Pholcidae):
     def before(self):
         print('-------- PRECRAWL ----------')
 
@@ -16,15 +16,25 @@ class MyTestSpider(Pholcidae):
         print(data.url, data.status)
 
     settings = {
-        'domain':       'www.python.org/~guido',
-        'start_page':   '/',
-        'valid_links':  ['(.*)'],
+        'domain': 'www.python.org/~guido',
+        'start_page': '/',
+        'valid_links': ['(.*)'],
         'exclude_links': ['ClaymontJPEGS'],
         'append_to_links': '?a=b',
         'precrawl': 'before',
         'postcrawl': 'after',
-        'callbacks': {'(.*)': 'my_callback'}
+        'callbacks': {'(.*)': 'my_callback'},
+        'threaded': True
     }
+
 
 spider = MyTestSpider()
 spider.start()
+
+try:
+    while spider.isAlive():
+        spider.join(5.0)
+except KeyboardInterrupt:
+    pass
+finally:
+    spider.stop()


### PR DESCRIPTION
I had a problem where I could not stop the spider with ctrl+c. As a solution it is now possible to launch the spider in a new thread.
In settings set 'threaded' to True and spider.start() becomes non-blocking. Since Pholcidae now inherits from [threading.Thread](https://docs.python.org/2/library/threading.html#thread-objects) you can use all those methods (.isAlive(), .join(),..) on it aswell. If you want to stop the crawl from outside the spider-thread, simple call spider.stop().
I have updated test.py to reflect this.
Also, 'threaded' defaults to False. Which means that if threading is not explicitly activated it is not used and behaves exactly the same as now (backward compatible)

added option to launch spider in new thread;
added start/stop functionality;
added **init**.py;
updated test.py;
PEP8 (flake8) compliant
